### PR TITLE
suggest proper use of markdown link styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 contains two principle component analysis examples.
 
-read about Zachary's Karate Club here - http://networkdata.ics.uci.edu/data.php?id=105
+read about Zachary's Karate Club [here](http://networkdata.ics.uci.edu/data.php?id=105)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 contains two principle component analysis examples.
 
-[read about Zachary's Karate Club](http://networkdata.ics.uci.edu/data.php?id=105) from which this work draws inspiration
+[read about Zachary's Karate Club](http://networkdata.ics.uci.edu/data.php?id=105) from which this work draws inspiration.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 contains two principle component analysis examples.
 
-[read about Zachary's Karate Club](http://networkdata.ics.uci.edu/data.php?id=105) from which this work draws inspiration.
+[Read about Zachary's Karate Club](https://en.wikipedia.org/wiki/Zachary%27s_karate_club) which this work relies upon.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 contains two principle component analysis examples.
 
-read about Zachary's Karate Club [here](http://networkdata.ics.uci.edu/data.php?id=105)
+[read about Zachary's Karate Club](http://networkdata.ics.uci.edu/data.php?id=105) from which this work draws inspiration


### PR DESCRIPTION
it's generally considered a best practice to avoid URLs in page text, instead using a link text of some sort.

Ideally, in this case, the actual text would be better as well, but perhaps that is an exercise best left for a future PR.